### PR TITLE
fix(examples): changed file paths in dinghyfile_localmodule_parameter…

### DIFF
--- a/examples/json/dinghyfile_localmodule_parameter
+++ b/examples/json/dinghyfile_localmodule_parameter
@@ -9,8 +9,8 @@
       "application": "localmodules",
       "name": "Made By Armory Pipeline Templates",
       "stages": [
-        {{ local_module "/examples/json/local_modules/stage.minimal.wait.localmodule" }},
-        {{ local_module "/examples/json/local_modules/stage.minimal.wait.localmodule" "waitname" "localmodule overwrite-name" "waitTime" "100" }},
+        {{ local_module "/local_modules/stage.minimal.wait.localmodule" }},
+        {{ local_module "/local_modules/stage.minimal.wait.localmodule" "waitname" "localmodule overwrite-name" "waitTime" "100" }},
         {{ module "stage.minimal.wait.module" "waitname" "global module overwrite-name" "waitTime" "100" }}
       ]
     }

--- a/examples/yaml/dinghyfile_localmodule_parameter
+++ b/examples/yaml/dinghyfile_localmodule_parameter
@@ -6,6 +6,6 @@ pipelines:
 - application: localmodules
   name: Made By Armory Pipeline Templates
   stages:
-{{ local_module "/examples/yaml/local_modules/stage.minimal.wait.localmodule" }}
-{{ local_module "/examples/yaml/local_modules/stage.minimal.wait.localmodule" "waitname" "localmodule overwrite-name" "waitTime" "100" }}
+{{ local_module "/local_modules/stage.minimal.wait.localmodule" }}
+{{ local_module "/local_modules/stage.minimal.wait.localmodule" "waitname" "localmodule overwrite-name" "waitTime" "100" }}
 {{ module "stage.minimal.wait.module" "waitname" "global module overwrite-name" "waitTime" "100" }}


### PR DESCRIPTION
… to match dinghyfile_localmodule which uses this path, excluding `/examples/json|yaml/`:
```
        {{ local_module "/local_modules/stage.minimal.wait.localmodule" }},
        {{ local_module "/local_modules/stage.minimal.wait.localmodule" "waitname" "localmodule overwrite-name" "waitTime" "100" }},
```
https://github.com/armory-io/arm/blob/master/examples/json/dinghyfile_localmodule